### PR TITLE
Q&A 작성 및 목록 출력 기능 구현

### DIFF
--- a/src/main/java/com/operation/controllers/BoardController.java
+++ b/src/main/java/com/operation/controllers/BoardController.java
@@ -20,6 +20,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.operation.constants.Constants;
 import com.operation.dto.BoardDTO;
+import com.operation.dto.QnaQuestionDTO;
 import com.operation.services.BoardService;
 import com.operation.services.MemberService;
 
@@ -102,7 +103,7 @@ public class BoardController {
 		dto.setMember_nickname(((String) session.getAttribute("loginNickName")));
 		bservice.insert(dto, attachFiles, deleteFileList);
 	}
-
+	
 	// 게시글 목록으로 이동
 	@RequestMapping("/listBoard/{catogory}")
 	public String listBoard(@PathVariable String catogory,

--- a/src/main/java/com/operation/controllers/QnAController.java
+++ b/src/main/java/com/operation/controllers/QnAController.java
@@ -6,7 +6,9 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -68,6 +70,16 @@ public class QnAController {
 	public void viewPost() {
 		// 질문글 출력
 	}
+	
+	// 게시글 출력
+	@RequestMapping("/viewQnaConf/{dataId}")
+	public String viewPostConf(@PathVariable String dataId, Model model) {
+		int postId = Integer.parseInt(dataId);
+		//Map<String, Object> post = qservice.selectPostByIdJustView(postId);
+		//model.addAttribute("post", post);
+		return "qna/viewQna";
+	}
+
 	
 	@RequestMapping("/updatePost")
 	public void updatePost() {

--- a/src/main/java/com/operation/controllers/QnAController.java
+++ b/src/main/java/com/operation/controllers/QnAController.java
@@ -1,11 +1,22 @@
 package com.operation.controllers;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.operation.constants.Constants;
+import com.operation.dto.QnaQuestionDTO;
 import com.operation.services.QnAService;
+
+import jakarta.servlet.http.HttpSession;
 
 @Controller
 @RequestMapping("/qna")
@@ -13,16 +24,45 @@ public class QnAController {
 	@Autowired
 	private QnAService qservice;
 	
-	@RequestMapping("/writePost")
-	public void writePost() {
-		// 질문글 작성
-	}
+	@Autowired
+	private HttpSession session;
 	
+	// QNA 게시글 작성
+	@ResponseBody
+	@RequestMapping("/writePost")
+	public void writePost(QnaQuestionDTO dto,
+			@RequestParam(value = "attachFiles", required = false) MultipartFile[] attachFiles,
+			@RequestParam(value = "deleteFileList", required = false) Integer[] deleteFileList) throws Exception {
+		dto.setMember_id(((String) session.getAttribute("loginID")));
+		dto.setMember_nickname(((String) session.getAttribute("loginNickName")));
+		qservice.insert(dto, attachFiles, deleteFileList);
+	}
+
+	// qna 게시글 목록으로 이동
 	@RequestMapping("/listBoard")
 	public String listBoard() {
-		// QNA 목록 출력
 		return "/qna/qnaList";
 	}
+	
+	
+	// qna 게시글 불러오기 
+	@ResponseBody
+	@RequestMapping("/selectPostAll")
+	public Map<String, Object> listBoard(@RequestParam(value = "cpage", required = false) String cpage) {
+		Map<String, Object> result = new HashMap<>();
+		int currentPage = (cpage == null || cpage.isEmpty()) ? 1 : Integer.parseInt(cpage);
+		List<Map<String,Object>> list = qservice.selectAll(currentPage);
+		int recordTotalCount = qservice.selectTotalCnt();
+		result.put("recordTotalCount", recordTotalCount);
+		result.put("recordCountPerPage", Constants.RECORD_COUNT_PER_PAGE);
+		result.put("naviCountPerPage", Constants.NAVI_COUNT_PER_PAGE);
+		result.put("postCurPage", currentPage);
+		result.put("userNick", (String) session.getAttribute("loginNickName"));
+		result.put("list", list);
+		
+		return result;
+	}
+	
 	
 	@RequestMapping("/viewPost")
 	public void viewPost() {

--- a/src/main/java/com/operation/dao/BoardDAO.java
+++ b/src/main/java/com/operation/dao/BoardDAO.java
@@ -1,6 +1,5 @@
 package com.operation.dao;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/operation/dao/FileDAO.java
+++ b/src/main/java/com/operation/dao/FileDAO.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import com.operation.dto.FileDTO;
+import com.operation.dto.QnaQuestionFileDTO;
 
 @Repository
 public class FileDAO {
@@ -19,6 +20,12 @@ public class FileDAO {
 	public int insert(FileDTO dto) {
 		return db.insert("File.insert",dto);
 	}
+	
+	// 파일 삽입
+	public int insert(QnaQuestionFileDTO dto) {
+		return db.insert("File.qnaInsert",dto);
+	}
+		
 	
 	// 파일 삭제
 	public int delete(Integer[] array) {

--- a/src/main/java/com/operation/dao/QnADAO.java
+++ b/src/main/java/com/operation/dao/QnADAO.java
@@ -1,8 +1,33 @@
 package com.operation.dao;
 
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+
+import com.operation.dto.QnaQuestionDTO;
 
 @Repository
 public class QnADAO {
-
+	
+	@Autowired
+	private SqlSession db;
+	
+	// 게시글 작성
+	public int insert(QnaQuestionDTO dto) {
+		db.insert("Qna.insert", dto);
+		return dto.getId();
+	}
+	
+	// qna 게시글 불러오기 
+	public List<Map<String,Object>> selectAll(Map<String, Object> param){
+		return db.selectList("Qna.selectAll",param);
+	}
+	
+	// qna 게시글 총 개수 불러오기
+	public int selectTotalCnt(){
+		return db.selectOne("Qna.selectTotalCnt");
+	}
 }

--- a/src/main/java/com/operation/dto/QnaQuestionDTO.java
+++ b/src/main/java/com/operation/dto/QnaQuestionDTO.java
@@ -9,7 +9,7 @@ public class QnaQuestionDTO {
 	private String title;
 	private String content;
 	private Timestamp write_date;
-	private boolean isSecret;
+	private boolean is_secret;
 	
 	public QnaQuestionDTO() {
 		super();
@@ -17,7 +17,7 @@ public class QnaQuestionDTO {
 	}
 	
 	public QnaQuestionDTO(int id, String member_id, String member_nickname, String title, String content,
-			Timestamp write_date, boolean isSecret) {
+			Timestamp write_date, boolean is_secret) {
 		super();
 		this.id = id;
 		this.member_id = member_id;
@@ -25,7 +25,7 @@ public class QnaQuestionDTO {
 		this.title = title;
 		this.content = content;
 		this.write_date = write_date;
-		this.isSecret = isSecret;
+		this.is_secret = is_secret;
 	}
 	
 	public int getId() {
@@ -64,10 +64,13 @@ public class QnaQuestionDTO {
 	public void setWrite_date(Timestamp write_date) {
 		this.write_date = write_date;
 	}
-	public boolean isSecret() {
-		return isSecret;
+
+	public boolean isIs_secret() {
+		return is_secret;
 	}
-	public void setSecret(boolean isSecret) {
-		this.isSecret = isSecret;
+
+	public void setIs_secret(boolean is_secret) {
+		this.is_secret = is_secret;
 	}
+	
 }

--- a/src/main/java/com/operation/dto/QnaQuestionFileDTO.java
+++ b/src/main/java/com/operation/dto/QnaQuestionFileDTO.java
@@ -2,23 +2,21 @@ package com.operation.dto;
 
 public class QnaQuestionFileDTO {
 	private int id;
-	private int qna_question_board__id;
+	private int qna_question_board_id;
 	private String system_name;
 	private String origin_name;
-	private boolean img;
 	
 	public QnaQuestionFileDTO() {
 		super();
 		// TODO Auto-generated constructor stub
 	}
 	
-	public QnaQuestionFileDTO(int id, int qna_question_board__id, String system_name, String origin_name, boolean img) {
+	public QnaQuestionFileDTO(int id, int qna_question_board_id, String system_name, String origin_name) {
 		super();
 		this.id = id;
-		this.qna_question_board__id = qna_question_board__id;
+		this.qna_question_board_id = qna_question_board_id;
 		this.system_name = system_name;
 		this.origin_name = origin_name;
-		this.img = img;
 	}
 	
 	public int getId() {
@@ -27,11 +25,11 @@ public class QnaQuestionFileDTO {
 	public void setId(int id) {
 		this.id = id;
 	}
-	public int getQna_question_board__id() {
-		return qna_question_board__id;
+	public int getQna_question_board_id() {
+		return qna_question_board_id;
 	}
-	public void setQna_question_board__id(int qna_question_board__id) {
-		this.qna_question_board__id = qna_question_board__id;
+	public void setQna_question_board_id(int qna_question_board_id) {
+		this.qna_question_board_id = qna_question_board_id;
 	}
 	public String getSystem_name() {
 		return system_name;
@@ -44,11 +42,5 @@ public class QnaQuestionFileDTO {
 	}
 	public void setOrigin_name(String origin_name) {
 		this.origin_name = origin_name;
-	}
-	public boolean isImg() {
-		return img;
-	}
-	public void setImg(boolean img) {
-		this.img = img;
 	}
 }

--- a/src/main/java/com/operation/services/BoardService.java
+++ b/src/main/java/com/operation/services/BoardService.java
@@ -13,14 +13,15 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.operation.constants.Constants;
 import com.operation.dao.BoardDAO;
 import com.operation.dao.FileDAO;
+import com.operation.dao.QnADAO;
 import com.operation.dto.BoardDTO;
 import com.operation.dto.FileDTO;
+import com.operation.dto.QnaQuestionDTO;
 
 import jakarta.servlet.http.HttpSession;
 
@@ -31,7 +32,7 @@ public class BoardService {
 
 	@Autowired
 	private FileDAO fdao;
-
+	
 	@Autowired
 	private HttpSession session;
 
@@ -69,6 +70,7 @@ public class BoardService {
 
 		}
 	}
+	
 
 	// 게시글 목록 불러오기
 	public List<Map<String, Object>> selectAll(String bulletin_category_id, int currentPage) {

--- a/src/main/java/com/operation/services/QnAService.java
+++ b/src/main/java/com/operation/services/QnAService.java
@@ -1,12 +1,75 @@
 package com.operation.services;
 
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.operation.constants.Constants;
+import com.operation.dao.FileDAO;
 import com.operation.dao.QnADAO;
+import com.operation.dto.QnaQuestionDTO;
+import com.operation.dto.QnaQuestionFileDTO;
 
 @Service
 public class QnAService {
 	@Autowired
 	private QnADAO dao;
+
+	@Autowired
+	private FileDAO fdao;
+	
+	// qna 업로드 (+ 파일 업로드)
+	@Transactional
+	public void insert(QnaQuestionDTO dto, MultipartFile[] files, Integer[] deleteFileList) throws Exception {
+		int qna_question_board_id = dao.insert(dto);
+		if (files != null && files.length >= 1) {
+			String path = "c:/003Operation/uploads";
+			File uploadPath = new File(path);
+			if (!uploadPath.exists())
+				uploadPath.mkdir();
+
+			if (deleteFileList != null && deleteFileList.length >= 1) {
+				int idx = 0;
+				System.out.println("길이: :" + deleteFileList.length);
+				for (int i = 0; i < files.length; i++) {
+					if (idx < deleteFileList.length && deleteFileList[idx] == i) {
+						idx++;
+						continue;
+					}
+					String oriName = files[i].getOriginalFilename();
+					String sysName = UUID.randomUUID() + "_" + oriName;
+					files[i].transferTo(new File(uploadPath, sysName));
+					fdao.insert(new QnaQuestionFileDTO(0, qna_question_board_id, sysName, oriName));
+				}
+			} else {
+				for (int i = 0; i < files.length; i++) {
+					String oriName = files[i].getOriginalFilename();
+					String sysName = UUID.randomUUID() + "_" + oriName;
+					files[i].transferTo(new File(uploadPath, sysName));
+					fdao.insert(new QnaQuestionFileDTO(0, qna_question_board_id, sysName, oriName));
+				}
+			}
+
+		}
+	}
+	
+	// qna 게시글 불러오기 
+	public List<Map<String,Object>> selectAll(int currentPage){
+		Map<String, Object> param = new HashMap<>();
+		param.put("start", currentPage * Constants.RECORD_COUNT_PER_PAGE - (Constants.RECORD_COUNT_PER_PAGE - 1) - 1);
+		param.put("count", Constants.RECORD_COUNT_PER_PAGE);
+		return dao.selectAll(param);
+	}
+	
+	// qna 게시글 총 개수 불러오기
+	public int selectTotalCnt(){
+		return dao.selectTotalCnt();
+	}
 }

--- a/src/main/resources/mappers/file-mapper.xml
+++ b/src/main/resources/mappers/file-mapper.xml
@@ -7,6 +7,10 @@
 	<insert id="insert">
 		insert into bulletin_board_file values (null, #{bulletin_board_id}, #{system_name}, #{origin_name});
 	</insert>
+
+	<insert id="qnaInsert">
+		insert into qna_question_board_file values (null, #{qna_question_board_id}, #{system_name}, #{origin_name});
+	</insert>
 	
 	<select id="selectAllByPostId" resultType="String">
 		select origin_name from bulletin_board_file where bulletin_board_id = ${bulletin_board_id}; 

--- a/src/main/resources/mappers/qna-mapper.xml
+++ b/src/main/resources/mappers/qna-mapper.xml
@@ -3,5 +3,30 @@
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="Qna">
+	<resultMap id="qna_info" type="java.util.Map">
+		<result property="id" column="id" />
+		<result property="member_id" column="member_id" />
+		<result property="member_nickname" column="member_nickname" />
+		<result property="title" column="title" />
+		<result property="content" column="content" />
+		<result property="write_date" column="write_date" />
+		<result property="write_date" column="write_date" />
+		<result property="file_cnt" column="file_cnt" />
+		<result property="anwser" column="anwser"/>
+	</resultMap>
+
+	<!-- 게시글 작성 -->
+	<insert id="insert" useGeneratedKeys="true" keyProperty="id">
+		insert into qna_question_board values (null, #{member_id}, #{member_nickname}, #{title}, #{content}, default, #{is_secret});
+	</insert>
 	
+	<!-- 게시글 목록 불러오기 -->
+	<select id="selectAll" resultMap="qna_info">
+		select * from qna_info order by id desc limit #{start},#{count};
+	</select>
+	
+	<!-- 게시글 개수 불러오기 -->
+	<select id="selectTotalCnt" resultType="int">
+		select count(*) from qna_info;
+	</select>
 </mapper>

--- a/src/main/resources/static/css/commons/common.css
+++ b/src/main/resources/static/css/commons/common.css
@@ -48,7 +48,11 @@ input[type="checkbox"] {
 }
 
 .colorMainBlue{
-  color: #375abb;
+	color: #375abb;
+}
+
+.ColorMainPink{
+	color:#FB8F8A;
 }
 
 .bColorMainBlue {

--- a/src/main/resources/static/css/kiosk/kiosk.css
+++ b/src/main/resources/static/css/kiosk/kiosk.css
@@ -10,11 +10,19 @@
 .kiosk__kioskName {
 	font-size: 30px;
 	font-weight: bold;
-	margin-bottom: 60px;
+	margin-bottom: 10px;
+}
+
+.kiosk__line{
+	margin-bottom: 30px;
+	height: 2.5px;
+	background-color: #7d7d7d50;
 }
 
 .kiosk__progressBar {
 	width: 100%;
+	margin-top:20px;
+	margin-bottom: 30px;
 }
 
 .progressBar__name {
@@ -54,10 +62,17 @@
 }
 
 .kiosk__area {
-	width: 100%;
-	height: 725px;
+	/* 버전 1 */
+	width: 1220px;
+	height: 735px;
+	
+	/* 버전 2 */
+	/*width: 640px;
+	height: 820px;*/
 	background-color: #D1D2D8;
+	margin:auto;
 	margin-top: 30px;
+	
 }
 
 .kiosk__recordName {

--- a/src/main/resources/static/css/qna/qnaList.css
+++ b/src/main/resources/static/css/qna/qnaList.css
@@ -119,6 +119,7 @@
 	background-color: #D1D2D8;
 	border-bottom: 3px solid #375ABB;
 	padding: 10px 0;
+	height: 60px;
 }
 
 .board__postHeader>div,
@@ -268,6 +269,11 @@
 	white-space: nowrap;
 }
 
+.empty{
+	height: 200px;
+	font-size: 20px;
+}
+
 @media (max-width: 786px) {
 	.guide {
 		margin: 100px 10px;
@@ -375,5 +381,9 @@
 		align-items: center;
 		justify-content: center;
 		margin: 0 2.5px;
+	}
+	
+	.empty{
+		height: 100px;
 	}
 }

--- a/src/main/resources/static/js/board/writePost.js
+++ b/src/main/resources/static/js/board/writePost.js
@@ -64,6 +64,13 @@ $(document).ready(function(){
 		else if($(".titleArea").text().slice(0,2)!="자유") bulletin_category_id = "qna";
 		formData.append("bulletin_category_id",bulletin_category_id);
 		
+		let url ="/board/writePost";
+		if(bulletin_category_id=="qna"){
+			// 비밀여부
+			formData.append("is_secret",$("#secretChk").is(":checked"));
+			url = "/qna/writePost";
+		}
+		
 		for(let i=0; i<$(".postArea__fileInput")[0].files.length; i++){
 			if(i==5) break;
 			formData.append("attachFiles",$(".postArea__fileInput")[0].files[i]);
@@ -71,7 +78,7 @@ $(document).ready(function(){
 		
 		// 공지글인지도 판단 필요
 		$.ajax({
-			url:"/board/writePost",
+			url:url,
 			type:"post",
 			data:formData,
 			contentType: false,
@@ -84,8 +91,10 @@ $(document).ready(function(){
 	// 수정 완료 버튼
 	$(".update").on("click",function(){
 		// 제목 입력 검사
-		if($(".postArea__titleInput").val()==""){
+		let title = $(".postArea__titleInput").val();
+		if(title==""||title.trim()==""){
 			alert("제목을 입력하세요.");
+			$(".postArea__titleInput").val("");
 			$(".postArea__titleInput").focus();
 			return;
 		}
@@ -122,6 +131,7 @@ $(document).ready(function(){
 		// 자유 vs 질문
 		let bulletin_category_id = "free";
 		if($(".titleArea").text().slice(0,2)=="질문") bulletin_category_id = "question";
+		else if($(".titleArea").text().slice(0,2)!="자유") bulletin_category_id = "qna";
 		
 		for(let i=0; i<$(".postArea__fileInput")[0].files.length; i++){
 			if(i==5) break;
@@ -143,7 +153,8 @@ $(document).ready(function(){
 	// 목록으로 버튼
 	$(".goList").on("click",function(){
 		let bulletin_category_id = "free";
-		if($(".titleArea").text().slice(0,2)=="질문") bulletin_category_id = question;
+		if($(".titleArea").text().slice(0,2)=="질문") bulletin_category_id = "question";
+		else if($(".titleArea").text().slice(0,2)!="자유") bulletin_category_id = "qna";
 		
 		// 수정중이었으면 삽입된 이미지 다시 삭제
 		$.ajax({
@@ -153,13 +164,15 @@ $(document).ready(function(){
 			data: { srcList : insertImgs }
 		});
 		
+		//if(bulletin_category_id=="qna") qna면 다른 링크로 이동
 		location.href="/board/listBoard/"+bulletin_category_id  + "?select=" + $("#select").val()+"&keyword="+$("#keyword").val();
 	});
 	
 	// 수정취소 버튼
 	$(".goPost").on("click",function(){
 		let bulletin_category_id = "free";
-		if($(".titleArea").text().slice(0,2)=="질문") bulletin_category_id = question;
+		if($(".titleArea").text().slice(0,2)=="질문") bulletin_category_id = "question";
+		else if($(".titleArea").text().slice(0,2)!="자유") bulletin_category_id = "qna";
 		
 		// 수정중이었으면 삽입된 이미지 다시 삭제
 		$.ajax({
@@ -169,6 +182,7 @@ $(document).ready(function(){
 			data: { srcList : insertImgs }
 		});
 		
+		//if(bulletin_category_id=="qna") qna면 다른 링크로 이동
 		location.href = "/board/viewPostConf/" + bulletin_category_id + "/" + $("#select").val() + "/" + $(".update").attr("data-id") +"?keyword="+$("#keyword").val();
 	});
 	

--- a/src/main/resources/static/js/board/writePost.js
+++ b/src/main/resources/static/js/board/writePost.js
@@ -84,7 +84,12 @@ $(document).ready(function(){
 			contentType: false,
 			processData: false
 		}).done(function(){
-			location.href="/board/listBoard/"+bulletin_category_id;
+			// 자유/질문
+			if(bulletin_category_id == "qna"){
+				location.href="/qna/listBoard";
+			}else{
+				location.href="/board/listBoard/"+bulletin_category_id;
+			}
 		});
 	});
 	

--- a/src/main/resources/static/js/kiosk/kiosk.js
+++ b/src/main/resources/static/js/kiosk/kiosk.js
@@ -1,5 +1,5 @@
 $(document).ready(function(){
-    $(".progressBar__fill").css("width","30%");
+/*    $(".progressBar__fill").css("width","30%");*/
     
     $.ajax({
 		url:"/kiosk/getBestRecord",

--- a/src/main/resources/static/js/qna/qnaListLoad.js
+++ b/src/main/resources/static/js/qna/qnaListLoad.js
@@ -1,50 +1,95 @@
 let keyword="";
 let select="";
 
-$(document).ready(function(){
-    for(let i=0; i<10; i++){
+function loadPost(list, user){
+	for(let i=0; i<list.length; i++){
         let board__post = $("<div>").attr("class","board__post d-flex");
-        let post__seq = $("<div>").attr("class","post__seq").text("1");
+        let post__seq = $("<div>").attr("class","post__seq").text(list[i].id);
 
         let post__cover = $("<div>").attr("class","post__cover");
         
         let post__title = $("<div>").attr("class","post__title d-flex");
 
+		let title__name = $("<div>").attr("class","title__name");
+		
 		// 비밀글이면 넣고 아니면 빼기
-        let title__secret = $("<div>").attr("class","title__secret").html("<i class='fa-solid fa-lock'></i>");
+		if(list[i].is_secret==1){
+			  let title__secret = $("<div>").attr("class","title__secret").html("<i class='fa-solid fa-lock'></i>");
+			  post__title.append(title__secret);
+			  
+			  if(list[i].nickname == user){
+				  title__name.text(list[i].title);
+			  }else{
+				  title__name.text("비공개 Q&A 게시글입니다.");
+			  }
+		}else{
+			title__name.text(list[i].title);
+		}
+      
 
-		let title__name = $("<div>").attr("class","title__name").text("자유게시판 제목인데용ㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎ");
+		
         let title__answerStateCover = $("<div>").attr("class","title__answerStateCover");
 
 		// 여부에 따라 bColorMainPink colorWhite / bColorLightGray colorGray
-        let title__answerState = $("<div>").attr("class","title__answerState align-center bColorMainPink colorWhite").text("답변여부");
-        post__title.append(title__secret).append(title__name).append(title__answerStateCover.append(title__answerState));
+		let title__answerState = $("<div>");
+		if(list[i].anwser==undefined){
+			title__answerState.attr("class","title__answerState align-center bColorLightGray colorGray").text("답변대기");
+		}else{
+			title__answerState.attr("class","title__answerState align-center bColorMainPink colorWhite").text("답변완료");
+		}
+        
+        post__title.append(title__name).append(title__answerStateCover.append(title__answerState));
 
 		let board__postAwswer = $("<div>").attr("class","board__postAwswer");
         let board__postMini = $("<div>").attr("class","board__postMini d-flex");
-        let postMini__writer = $("<div>").attr("class","postMini__writer").text("작성자");
-        let postMini__writeDate = $("<div>").attr("class","postMini__writeDate").html("<i class='fa-regular fa-calendar-days'></i>"+"2023-11-10");
-        let postMini__file = $("<div>").attr("class","postMini__file").html("<i class='fa-solid fa-paperclip'></i>");
-		board__postMini.append(postMini__writer).append(postMini__writeDate).append(postMini__file);
-
-		let postAwswer__area = $("<div>").attr("class","postAwswer__area colorMainBlue").html("답변 미리보기 <i class='fa-solid fa-chevron-down colorMainBlue'></i>");
-		let postAnswer__content = $("<div>").attr("class","postAnswer__content").text("해당 문제는 오랜 시간 창을 켜둔 채로");
-
-        board__postAwswer.append(board__postMini).append(postAwswer__area).append(postAnswer__content);
-
+        let postMini__writer = $("<div>").attr("class","postMini__writer").text(list[i].member_nickname);
+        let postMini__writeDate = $("<div>").attr("class","postMini__writeDate").html("<i class='fa-regular fa-calendar-days'></i>"+list[i].write_date.slice(0,11));
+        board__postMini.append(postMini__writer).append(postMini__writeDate);
+        if(list[i].file_cnt > 0){
+			let postMini__file = $("<div>").attr("class","postMini__file").html("<i class='fa-solid fa-paperclip'></i>");
+			board__postMini.append(postMini__file);
+		}
+        
+    
+        if(list[i].anwser!=undefined){
+			let postAwswer__area = $("<div>").attr("class","postAwswer__area colorMainBlue").html("답변 미리보기 <i class='fa-solid fa-chevron-down colorMainBlue'></i>");
+			let postAnswer__content = $("<div>").attr("class","postAnswer__content").text(list[i].anwser)
+			board__postAwswer.append(board__postMini).append(postAwswer__area).append(postAnswer__content);
+		}
 	
-
         post__cover.append(post__title).append(board__postAwswer);
+        
+        let post__anwserState = $("<div>");
+		if(list[i].anwser==undefined){
+			post__anwserState.attr("class","post__anwserState").text("답변대기");
+		}else{
+			post__anwserState.attr("class","post__anwserState ColorMainPink").text("답변완료");
+		}
 
-		let post__anwserState = $("<div>").attr("class","post__anwserState").text("답변대기");
-        let post__writer = $("<div>").attr("class","post__writer").text("작성자");
-        let post__writeDate = $("<div>").attr("class","post__writeDate").text("2023-11-10");
-        let post__file = $("<div>").attr("class","post__file").html("<i class='fa-solid fa-paperclip'></i>")
+        let post__writer = $("<div>").attr("class","post__writer").text(list[i].member_nickname);
+        let post__writeDate = $("<div>").attr("class","post__writeDate").text(list[i].write_date.slice(0,11));
         board__post.append(post__seq).append(post__cover);
-        board__post.append(post__anwserState).append(post__writer).append(post__writeDate).append(post__file);
+        board__post.append(post__anwserState).append(post__writer).append(post__writeDate);
+        if(list[i].file_cnt > 0){
+			let post__file = $("<div>").attr("class","post__file").html("<i class='fa-solid fa-paperclip'></i>")
+			board__post.append(post__file);
+		}
+     
 
         $(".board__posts").append(board__post);
     }
+}
+
+$(document).ready(function(){
+	
+	$.ajax({
+		url:"/qna/selectPostAll"
+	}).done(function(resp){
+		console.log(resp);
+		loadPost(resp.list, resp.userNick)
+	});
+	
+    
 
 	
 	

--- a/src/main/resources/static/js/qna/qnaListLoad.js
+++ b/src/main/resources/static/js/qna/qnaListLoad.js
@@ -1,7 +1,12 @@
-let keyword="";
-let select="";
-
-function loadPost(list, user){
+function postLoad(result){
+	let recordTotalCount = result.recordTotalCount;
+	$(".postCnt__txt").text(recordTotalCount);
+	let recordCountPerPage = result.recordCountPerPage;
+	let naviCountPerPage = result.naviCountPerPage;
+	let postCurPage = result.postCurPage;
+	let list = result.list;
+	let user = result.userNick;
+	
 	for(let i=0; i<list.length; i++){
         let board__post = $("<div>").attr("class","board__post d-flex");
         let post__seq = $("<div>").attr("class","post__seq").text(list[i].id);
@@ -10,14 +15,14 @@ function loadPost(list, user){
         
         let post__title = $("<div>").attr("class","post__title d-flex");
 
-		let title__name = $("<div>").attr("class","title__name");
+		let title__name = $("<div>").attr("class","title__name").attr("data-id", list[i].id);
 		
 		// 비밀글이면 넣고 아니면 빼기
 		if(list[i].is_secret==1){
 			  let title__secret = $("<div>").attr("class","title__secret").html("<i class='fa-solid fa-lock'></i>");
 			  post__title.append(title__secret);
 			  
-			  if(list[i].nickname == user){
+			  if(list[i].member_nickname == user){
 				  title__name.text(list[i].title);
 			  }else{
 				  title__name.text("비공개 Q&A 게시글입니다.");
@@ -25,8 +30,6 @@ function loadPost(list, user){
 		}else{
 			title__name.text(list[i].title);
 		}
-      
-
 		
         let title__answerStateCover = $("<div>").attr("class","title__answerStateCover");
 
@@ -74,26 +77,20 @@ function loadPost(list, user){
 			let post__file = $("<div>").attr("class","post__file").html("<i class='fa-solid fa-paperclip'></i>")
 			board__post.append(post__file);
 		}
-     
-
         $(".board__posts").append(board__post);
     }
+    drawPagination(recordTotalCount, postCurPage, recordCountPerPage, naviCountPerPage);
 }
 
 $(document).ready(function(){
-	
 	$.ajax({
 		url:"/qna/selectPostAll"
 	}).done(function(resp){
 		console.log(resp);
-		loadPost(resp.list, resp.userNick)
+		postLoad(resp);
 	});
-	
-    
-
-	
-	
 });
+
 $(document).on("click",".postAwswer__area",function(){		
 	if($(this).next().hasClass("abled")){
 		$(this).next().removeClass("abled");
@@ -149,11 +146,7 @@ function drawPagination(recordTotalCount, postCurPage, recordCountPerPage, naviC
 			let iTag = $("<i class='fa-solid fa-angles-left'></i>");
 			aTag.attr("class", "fontEnglish");
 			aTag.on("click", function() {
-				if (select != "") {
-					search(1);
-				} else {
-					postLoad(1);
-				}
+				postLoad(1);
 			});
 			aTag.append(iTag);
 			pagination.append(aTag);
@@ -163,11 +156,7 @@ function drawPagination(recordTotalCount, postCurPage, recordCountPerPage, naviC
 			let aTag = $("<a>");
 			let iTag = $("<i class='fa-solid fa-chevron-left'></i>");
 			aTag.on("click", function() {
-				if (select != "") {
-					search((startNavi - 1));
-				} else {
-					postLoad((startNavi - 1));
-				}
+				postLoad((startNavi - 1));
 			});
 			aTag.append(iTag);
 			pagination.append(aTag);
@@ -178,11 +167,7 @@ function drawPagination(recordTotalCount, postCurPage, recordCountPerPage, naviC
 			aTag.html(i);
 			aTag.attr("class", "fontEnglish");
 			aTag.on("click", function() {
-				if (select != "") {
-					search(i);
-				} else {
-					postLoad(i);
-				}
+				postLoad(i);
 			});
 			if (i == postCurPage) {
 				aTag.addClass("colorWhite bColorMainBlue fontEnglish");
@@ -196,11 +181,7 @@ function drawPagination(recordTotalCount, postCurPage, recordCountPerPage, naviC
 			let aTag = $("<a>");
 			let iTag = $("<i class='fa-solid fa-chevron-right'></i>");
 			aTag.on("click", function() {
-				if (select != "") {
-					search(endNavi + 1);
-				} else {
-					postLoad(endNavi + 1);
-				}
+				postLoad(endNavi + 1);
 			});
 			aTag.append(iTag);
 			pagination.append(aTag);
@@ -210,11 +191,7 @@ function drawPagination(recordTotalCount, postCurPage, recordCountPerPage, naviC
 			let aTag = $("<a>");
 			let iTag = $("<i class='fa-solid fa-angles-right'></i>");
 			aTag.on("click", function() {
-				if (select != "") {
-					search(pageTotalCount);
-				} else {
-					postLoad(pageTotalCount);
-				}
+				postLoad(pageTotalCount);
 			});
 			aTag.append(iTag);
 			pagination.append(aTag);
@@ -225,5 +202,17 @@ function drawPagination(recordTotalCount, postCurPage, recordCountPerPage, naviC
 
 // 글 쓰기로 이동
 $(document).on("click",".board__writeBtn",function(){
-	location.href= "/board/goWritePost/qna?select="+select+"&keyword="+keyword;
+	location.href= "/board/goWritePost/qna";
+})
+
+
+
+// 게시글 보기 페이지로 이동
+$(document).on("click", ".title__name", function() {
+	let url = "/qna/viewQnaConf";
+
+	url += "/" + $(this).attr("data-id");
+
+	console.log(url);
+	location.href = url;
 })

--- a/src/main/webapp/WEB-INF/jsp/kiosk/kiosk.jsp
+++ b/src/main/webapp/WEB-INF/jsp/kiosk/kiosk.jsp
@@ -17,7 +17,7 @@
         <div class="guide">
             <div class="kiosk__kioskStep">[ ${info.play_stage}단계 ]</div>
             <div class="kiosk__kioskName" data-id="${info.kiosk_category_id}">${info.name}</div>
-            <c:choose>
+<%--             <c:choose>
             	<c:when test="${info.is_game}">
            			<div class="kiosk__progressBar d-flex">
 		                <div class="progressBar__name">진행도</div>
@@ -25,10 +25,10 @@
 		                <div class="progressBar__per">100%</div>
 		            </div>
             	</c:when>
-            </c:choose>
-            
+            </c:choose> --%>
+            <hr class="kiosk__line">
             <div class="kiosk__area">
-            	<iframe id="kioskFrame" title="kiosk frame" width="100%" height="100%" src="https://pushssun.github.io/${info.url}"></iframe>
+            	<iframe id="kioskFrame" title="kiosk frame" width="100%" height="100%" src="https://pushssun.github.io/TORDERTest1/"></iframe>
             </div>
             
             <!-- 기록 영역 ( 게임용 ) -->

--- a/src/main/webapp/WEB-INF/jsp/kiosk/kiosk.jsp
+++ b/src/main/webapp/WEB-INF/jsp/kiosk/kiosk.jsp
@@ -28,7 +28,7 @@
             </c:choose> --%>
             <hr class="kiosk__line">
             <div class="kiosk__area">
-            	<iframe id="kioskFrame" title="kiosk frame" width="100%" height="100%" src="https://pushssun.github.io/TORDERTest1/"></iframe>
+            	<iframe id="kioskFrame" title="kiosk frame" width="100%" height="100%" src="https://kiosk003.github.io/${info.url}"></iframe>
             </div>
             
             <!-- 기록 영역 ( 게임용 ) -->

--- a/src/main/webapp/WEB-INF/jsp/qna/qnaList.jsp
+++ b/src/main/webapp/WEB-INF/jsp/qna/qnaList.jsp
@@ -18,27 +18,9 @@
         <div class="guide">
             <div class="board__header">
                 <div class="board__title align-center">Q&A 게시판</div>
-                <div class="board__serach align-center">
-                    <div class="search__key align-center">
-                        <div class="search__selectCover">
-                            <select class="search__select">
-                                <option value="title">제목</option>
-                                <option value="content">내용</option>
-                                <option value="writer">작성자</option>
-                            </select>
-                            <span class="search__arrow"><i class="fa-solid fa-chevron-down"></i></span>
-                        </div>
-                    </div>
-                    <div class="search__value align-center">
-                        <input type="text" placeholder="검색어를 입력해주세요.">
-                    </div>
-                    <div class="search__btnCover  align-center">
-                        <button class="search__btn bColorMainPink colorWhite">검색</button>
-                    </div>
-                </div>
             </div>
             <div class="board__body">
-                <div class="board__postCnt">전체 <span class="postCnt__txt colorMainBlue">20</span>건</div>
+                <div class="board__postCnt">전체 <span class="postCnt__txt colorMainBlue"></span>건</div>
                 <div class="board__postHeader align-center">
                     <div class="postHeader__seq">번호</div>
                     <div class="postHeader__title">제목</div>

--- a/src/main/webapp/WEB-INF/jsp/qna/viewQna.jsp
+++ b/src/main/webapp/WEB-INF/jsp/qna/viewQna.jsp
@@ -1,0 +1,118 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core"%>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>${post.title }</title>
+<script src="https://code.jquery.com/jquery-3.7.1.js"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" />
+
+<!-- 공통 css -->
+<link rel="syplesheet" href="/css/commons/common.css"/>
+
+<link rel="stylesheet" href="/css/board/viewPost.css">
+</head>
+<body>
+ <div class="container">
+	<%@ include file="/WEB-INF/jsp/commons/header.jsp" %>
+    <div class="boardPost_guide">
+        <div class="boardType">${type } 게시판</div>
+        <div class="boardPost">
+        	<div class="naviBackground">
+         	<div class="stickyContainer">
+         		<div class="boardPost__navi">
+         			<input type="hidden" id="myRecommendRecord">
+         			<input type="hidden" id="myBookmarkRecord">
+                  <div class="navi__conf">
+                      <div class="conf__circle" id="recommendBtn">
+                          <i class="fa-regular fa-thumbs-up"></i>
+                          <div>추천 <span class="conf__miniCount recommendCount"></span></div>
+                      </div>
+                      <div class="conf__count recommendCount"></div>
+                  </div>
+                  <div class="navi__conf">
+                      <div class="conf__circle" id="bookmarkBtn">
+                          <i class="fa-regular fa-bookmark"></i>
+                          <div>북마크<span class="conf__miniCount bookmarkCount"></span></div>
+                      </div>
+                      <div class="conf__count bookmarkCount"></div>
+                  </div>
+                  <div class="navi__conf">
+                      <div class="conf__circle">
+                          <i class="fa-regular fa-comment"></i>
+                          <div>댓글<span class="conf__miniCount replyCount"></span></div>
+                      </div>
+                      <div class="conf__count replyCount"></div>
+                  </div>
+                  <div class="navi__conf">
+                      <div class="conf__circle">
+                          <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                          <div>공유</div>
+                      </div>
+                  </div>
+                  <div class="navi__conf">
+                      <div class="conf__circle" id="boardListBtn">
+                          <i class="fa-solid fa-list"></i>
+                          <div>목록</div>
+                      </div>
+                  </div>
+              </div>
+         	</div>
+         	
+        	</div>
+ 
+            <div class="boardPost__guide">
+            	<input type="hidden" value="${post.id }" id="postId">
+
+                <div class="postTitle">
+                    ${post.title }
+                </div>
+                <div class="postInfo">
+                    <div class="postInfo__left">
+                        <div class="postInfo__profile">
+                        	<input type="hidden" value="${post.member_id }" id="writerId">
+                            <img src="" alt="프로필 이미지" id="writer_profile">
+                        </div>
+                        <div class="postInfo__userInfo">
+                            <div class="userInfo__nickName fontEN">${post.member_nickname }</div>
+                            <div class="userInfo__writeInfo">
+                                <span class="writeInfo__title">작성일</span>
+                                <span>${post.write_date }</span>
+                                <span class="writeInfo__title">조회수</span>
+                                <span>${post.view_count }</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="postInfo__right">
+                        <button id="postUpdate" data-id="${post.id }">수정</button>
+                        <button id="postDelete" data-id="${post.id }">삭제</button>
+                    </div>
+                </div>
+                <div class="postConf">${post.content }
+                </div>
+                <div class="files">
+                    <div class="files__title">
+                        첨부파일
+                    </div>
+                    <div class="files__conf">
+                        
+                    </div>
+                </div>
+                <div class="pageBtns">
+
+                </div>
+            </div>
+        </div>
+    
+    	<div class="qnaAnwser">
+    	
+    	</div>
+    </div>
+    
+    
+    <%@ include file="/WEB-INF/jsp/commons/footer.jsp" %>
+</div>
+</body>
+</html>


### PR DESCRIPTION
1. QnaController
- writePost: qna 게시글 작성
- listBoard: qna 목록 출력
- viewQnaConf: qna 게시판 목록에서 제목 클릭 시 qna 게시글 상세보기 페이지로 이동 (기능 미구현)

2. FileDAO
- insert 함수 오버로딩: qna용 파일 insert

3. QnaDAO
- insert: 게시글 작성
- selectAll: 게시글 전체 목록 불러오기
- selectTotalCnt: 게시글 전체 개수 불러오기 (페이지네이션용)

4. QnaQuestionDTO
- isShare: 스네이크 케이스 -> 카멜케이스로 변경

5.  QnaQuestionFileDTO
- qna_question_board__id: 속성명 _(언더바)가 2개 들어간 것 확인 -> 변경
- img 속성 삭제 (DB에 이미지 파일은 따로 저장하지 않기 떄문에 정보가 필요없음.)

6. /board/writePost.js
- qna와 페이지 공유함에 따라, 카테고리 속성 추가 및 ajax 요청 url 동적 변경